### PR TITLE
Fix typo in example Dataset

### DIFF
--- a/docs/writing_datasets.rst
+++ b/docs/writing_datasets.rst
@@ -42,7 +42,7 @@ returns an input vector and its corresponding label:
         def __getitem__(self, idx):
             return (self.X[idx], self.Y[idx])
 
-        def __len(self):
+        def __len__(self):
             return len(self.X)
 
     N, d = (100, 6)


### PR DESCRIPTION
 \_\_len\_\_ method of LinearRegressionDataset class was defined as __len