### PR TITLE
Add MacOS support

### DIFF
--- a/ffcv/libffcv.py
+++ b/ffcv/libffcv.py
@@ -3,9 +3,10 @@ from numba import njit
 import numpy as np
 from ctypes import CDLL, c_int64, c_uint8, c_uint64, POINTER, c_void_p, c_uint32, c_bool, cdll
 import ffcv._libffcv
+from ctypes.util import find_library
 
 lib = CDLL(ffcv._libffcv.__file__)
-libc = cdll.LoadLibrary('libc.so.6')
+libc = cdll.LoadLibrary(find_library('c'))
 
 read_c = libc.pread
 read_c.argtypes = [c_uint32, c_void_p, c_uint64, c_uint64]


### PR DESCRIPTION
Edit: Resolves #51 

Attempt to fix OSError in MacOS:
`OSError: dlopen(libc.so.6, 0x0006): tried: '/Users/**/opt/anaconda3/envs/ffcv/lib/python3.9/lib-dynload/../../libc.so.6' (no such file), '/Users/**/opt/anaconda3/envs/ffcv/bin/../lib/libc.so.6' (no such file), 'libc.so.6' (no such file), '/usr/local/lib/libc.so.6' (no such file), '/usr/lib/libc.so.6' (no such file), '/Users/**/libc.so.6' (no such file), '/usr/local/lib/libc.so.6' (no such file), '/usr/lib/libc.so.6' (no such file)`