### PR TITLE
A few typos in the quickstart.rst

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -18,15 +18,15 @@ PyTorch datasets and `WebDatasets <https://github.com/webdataset/webdataset>`_):
     # Pass a type for each data field
     writer = DatasetWriter(write_path, {
         # Tune options to optimize dataset size, throughput at train-time
-        'image': RGBImageField({
+        'image': RGBImageField(dict(
             max_resolution=256,
             jpeg_quality=jpeg_quality
-        }),
+        )),
         'label': IntField()
     })
 
     # Write dataset
-    writer.from_indexed_dataset(ds)
+    writer.from_indexed_dataset(my_dataset)
 
 Then replace your old loader with the `ffcv` loader at train time (in PyTorch,
 no other changes required!):

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -18,10 +18,10 @@ PyTorch datasets and `WebDatasets <https://github.com/webdataset/webdataset>`_):
     # Pass a type for each data field
     writer = DatasetWriter(write_path, {
         # Tune options to optimize dataset size, throughput at train-time
-        'image': RGBImageField(dict(
+        'image': RGBImageField(
             max_resolution=256,
             jpeg_quality=jpeg_quality
-        )),
+        ),
         'label': IntField()
     })
 


### PR DESCRIPTION
A few typos corrections for the first snippet:
1) A syntax mistake `{max_resolution=256, jpeg_quality=jpeg_quality}` (should be either `dict(max_resolution=256, jpeg_quality=jpeg_quality)` or `{'max_resolution': 256, 'jpeg_quality': jpeg_quality}`)
2) A typo in `writer.from_indexed_dataset(ds)` -- perhaps should be `my_dataset` not `ds`.