### PR TITLE
Fix opposite os_cache behavior when creating Loader

### DIFF
--- a/ffcv/loader/loader.py
+++ b/ffcv/loader/loader.py
@@ -141,10 +141,10 @@ class Loader:
             self.indices = np.array(indices)
 
         if os_cache:
-            self.memory_manager: MemoryManager = OSCacheManager(self.reader)
-        else:
             self.memory_manager: MemoryManager = ProcessCacheManager(
                 self.reader)
+        else:
+            self.memory_manager: MemoryManager = OSCacheManager(self.reader)
 
         self.traversal_order: TraversalOrder = ORDER_MAP[order](self)
 


### PR DESCRIPTION
This small patch fixes the issue that os_cache behaves oppositely compared to declared in the document (https://docs.ffcv.io/parameter_tuning.html#scenario-large-scale-datasets).
According to the document, when os_cache=True, FFCV will cache the whole dataset in RAM, thus ProcessCacheManager() should be used, which creates an np array in the memory.
When os_cache=False, OSCacheManager() should be used, which uses np.memmap().

The current version is loading the whole dataset to RAM when os_cache=False.