### PR TITLE
Add option to seed numba RNG

### DIFF
--- a/ffcv/loader/epoch_iterator.py
+++ b/ffcv/loader/epoch_iterator.py
@@ -4,6 +4,7 @@ from queue import Queue, Full
 from contextlib import nullcontext
 from typing import Sequence, TYPE_CHECKING
 
+import numpy as np
 import torch as ch
 
 from ..traversal_order.quasi_random import QuasiRandom
@@ -66,6 +67,7 @@ class EpochIterator(Thread):
         self.start()
 
     def run(self):
+        Compiler.compile(lambda seed: np.random.seed(seed))(self.loader.seed)
 
         events = [None for _ in self.cuda_streams]
 


### PR DESCRIPTION
Calling `numpy.random.seed` at the start of code can set the global seed for all `numpy.random` methods.
However, calling this method from Python does not seed the `numba` generator, so `numba` JIT-compiled code is nondeterministic (e.g., the `cutout_square()` function returned by `generate_code()` in the `Cutout` operation).
[See this `numba` documentation for further details.](https://numba.pydata.org/numba-doc/dev/reference/numpysupported.html#modules)
Adding an optional `seed` argument to such random transforms allows reproducibility across runs.