### PR TITLE
Avoid in-place copy in the `ToDevice` `Operation`

### DIFF
--- a/ffcv/transforms/ops.py
+++ b/ffcv/transforms/ops.py
@@ -50,7 +50,7 @@ class ToDevice(Operation):
             if len(inp.shape) == 4 and inp.is_contiguous(memory_format=ch.channels_last):
                 inp = inp.reshape(B, inp.shape[2], inp.shape[3], inp.shape[1])
                 inp = inp.permute(0, 3, 1, 2)
-            inp = inp[:B].to(self.device)
+            inp = inp[:B].to(self.device, non_blocking=self.non_blocking)
             return inp
 
         return to_device

--- a/ffcv/transforms/ops.py
+++ b/ffcv/transforms/ops.py
@@ -46,13 +46,12 @@ class ToDevice(Operation):
 
     def generate_code(self) -> Callable:
         def to_device(inp, dst):
-            if len(inp.shape) == 4:
-                if inp.is_contiguous(memory_format=ch.channels_last):
-                    dst = dst.reshape(inp.shape[0], inp.shape[2], inp.shape[3], inp.shape[1])
-                    dst = dst.permute(0, 3, 1, 2)
-            dst = dst[:inp.shape[0]]
-            dst.copy_(inp, non_blocking=self.non_blocking)
-            return dst
+            B = inp.shape[0]
+            if len(inp.shape) == 4 and inp.is_contiguous(memory_format=ch.channels_last):
+                inp = inp.reshape(B, inp.shape[2], inp.shape[3], inp.shape[1])
+                inp = inp.permute(0, 3, 1, 2)
+            inp = inp[:B].to(self.device)
+            return inp
 
         return to_device
 


### PR DESCRIPTION
Avoids the error:
```python
RuntimeError: one of the variables needed for gradient computation has been modified by an inplace operation: [torch.cuda.LongTensor [128]] is at version 3; expected version 2 instead. Hint: enable anomaly detection to find the operation that failed to compute its gradient, with torch.autograd.set_detect_anomaly(True).
```

On an ImageNet example when the label pipeline has:

```python
    label_pipeline = [
        ...
        ToDevice(ch.device("cuda"), non_blocking=True),
    ]
    return Loader(
        ...
        pipelines={..., "label": label_pipeline},
    )
```
and prefetching is done by the user (in this case Lightning).

The underlying problem might be a bug in the autograd engine because the error has a race-y nature and does not appear when training is slowed down artificially.
In fact, it does not appear when anomaly detection is enabled or a `sleep(0.25)` call is added to the training step.