### PR TITLE
Add sampler attribute to TraversalOrder

### DIFF
--- a/ffcv/traversal_order/base.py
+++ b/ffcv/traversal_order/base.py
@@ -13,6 +13,7 @@ class TraversalOrder(ABC):
         self.indices = self.loader.indices
         self.seed = self.loader.seed
         self.distributed = loader.distributed
+        self.sampler = None
 
     @abstractmethod
     def sample_order(self, epoch:int) -> Sequence[int]:


### PR DESCRIPTION
Quick change. 
Most traversal orders will have to use torch's `DistributedSampler` anyways, and the attribute is filled by implementations of `TraversalOrder`. 