### PR TITLE
Fix bug in cifar-10 example training script; takes accuracy ~92.5% -> ~94%

### DIFF
--- a/examples/cifar/train_cifar.py
+++ b/examples/cifar/train_cifar.py
@@ -185,7 +185,7 @@ def evaluate(model, loaders, lr_tta=False):
                 with autocast():
                     out = model(ims)
                     if lr_tta:
-                        out += model(ch.fliplr(ims))
+                        out += model(ims.flip(-1))
                     total_correct += out.argmax(1).eq(labs).sum().cpu().item()
                     total_num += ims.shape[0]
             print(f'{name} accuracy: {total_correct / total_num * 100:.1f}%')


### PR DESCRIPTION
I was playing around with the example training script for CIFAR-10 and noticed that removing test-time augmentation improved my results from around 92-92.5% to 93% accuracy on the test set. It turns out that `torch.fliplr` isn't behaving as desired on batches of images, in particular it is causing a vertical rather than horizontal flip. Fixing this bug improves the accuracy with TTA to ~94%.

Here's a demonstration of the basic problem:
```
>>> img_t = torch.tensor([[[1, 2, 3],
                       [4, 5, 6],
                       [7, 8, 9]]])
>>> torch.fliplr(img_t), img_t.flip(-1)
(tensor([[[7, 8, 9],
          [4, 5, 6],
          [1, 2, 3]]]),
 tensor([[[3, 2, 1],
          [6, 5, 4],
          [9, 8, 7]]]))
```

And here are the results of running the training script before/after fixing.

Before fixing:
```
Total time: 37.84584
...
train accuracy: 98.0%
...
test accuracy: 92.3%
```

After fixing:
```
Total time: 37.21039
...
train accuracy: 99.6%
...
test accuracy: 94.2%
```

Thanks for the nice library!