### PR TITLE
increment loading index regardless of CUDA

### DIFF
--- a/ffcv/loader/epoch_iterator.py
+++ b/ffcv/loader/epoch_iterator.py
@@ -98,7 +98,7 @@ class EpochIterator(Thread):
                     event = ch.cuda.Event()
                     event.record(ch.cuda.default_stream())
                     events[just_finished_slot] = event
-                    b_ix += 1
+                b_ix += 1
 
         except StopIteration:
             self.output_queue.put(None)


### PR DESCRIPTION
Fixes #206. Although the installation instructions install CUDA and a compatible PyTorch version

https://github.com/libffcv/ffcv/blob/f25386557e213711cc8601833add36ff966b80b2/README.md?plain=1#L38

I didn't find a hint or the like that CUDA is required. The presence of a flag like

https://github.com/libffcv/ffcv/blob/f25386557e213711cc8601833add36ff966b80b2/ffcv/loader/epoch_iterator.py#L16

also supports that.