### PR TITLE
Fix RandomTranslate

### DIFF
--- a/ffcv/transforms/translate.py
+++ b/ffcv/transforms/translate.py
@@ -30,12 +30,12 @@ class RandomTranslate(Operation):
     def generate_code(self) -> Callable:
         my_range = Compiler.get_iterator()
         pad = self.padding
+        fill = self.fill
 
         def translate(images, dst):
-            n, h, w, _ = images.shape
-            # y_coords = randint(low=0, high=2 * pad + 1, size=(n,))
-            # x_coords = randint(low=0, high=2 * pad + 1, size=(n,))
-            # dst = fill
+            n, h, w, c = images.shape
+            for channel in range(c):
+                dst[..., channel] = fill[channel]
 
             dst[:, pad:pad+h, pad:pad+w] = images
             for i in my_range(n):


### PR DESCRIPTION
Currently `RandomTranslate` does not use the `fill` argument and instead puts random (garbage) values in the padding. The proposed changes fix this.