### PR TITLE
Modify Tests to Run on Consumer Hardware

### DIFF
--- a/tests/test_basic_pipeline.py
+++ b/tests/test_basic_pipeline.py
@@ -12,6 +12,7 @@ from assertpy import assert_that
 from tempfile import NamedTemporaryFile
 from ffcv.pipeline.operation import Operation
 from ffcv.transforms.ops import ToTensor
+from multiprocessing import cpu_count
 
 from ffcv.writer import DatasetWriter
 from ffcv.reader import Reader
@@ -52,7 +53,7 @@ def test_basic_simple():
 
         Compiler.set_enabled(True)
 
-        loader = Loader(file_name, batch_size, num_workers=5, seed=17,
+        loader = Loader(file_name, batch_size, num_workers=min(5, cpu_count()), seed=17,
                         pipelines={
                             'value': [FloatDecoder(), Doubler(), ToTensor()]
                         })
@@ -63,7 +64,7 @@ def test_basic_simple():
                                 np.arange(batch_size))).is_true()
         assert_that(np.allclose(2 * np.sin(np.arange(batch_size)),
                                 values.squeeze().numpy())).is_true()
-        
+
 def test_multiple_iterators_success():
     length = 60
     batch_size = 8
@@ -79,7 +80,7 @@ def test_multiple_iterators_success():
 
         Compiler.set_enabled(True)
 
-        loader = Loader(file_name, batch_size, num_workers=5, seed=17,
+        loader = Loader(file_name, batch_size, num_workers=min(5, cpu_count()), seed=17,
                         pipelines={
                             'value': [FloatDecoder(), Doubler(), ToTensor()]
                         })
@@ -102,7 +103,7 @@ def test_multiple_epoch_doesnt_recompile():
 
         Compiler.set_enabled(True)
 
-        loader = Loader(file_name, batch_size, num_workers=5, seed=17,
+        loader = Loader(file_name, batch_size, num_workers=min(5, cpu_count()), seed=17,
                         pipelines={
                             'value': [FloatDecoder(), Doubler(), ToTensor()]
                         })
@@ -128,7 +129,7 @@ def test_multiple_epoch_does_recompile():
 
         Compiler.set_enabled(True)
 
-        loader = Loader(file_name, batch_size, num_workers=5, seed=17,
+        loader = Loader(file_name, batch_size, num_workers=min(5, cpu_count()), seed=17,
                 recompile=True,
                         pipelines={
                             'value': [FloatDecoder(), Doubler(), ToTensor()]

--- a/tests/test_json_field.py
+++ b/tests/test_json_field.py
@@ -2,7 +2,7 @@ import string
 from ctypes import pointer
 from tempfile import NamedTemporaryFile
 from collections import defaultdict
-from assertpy.assertpy import assert_that
+from multiprocessing import cpu_count
 
 from assertpy import assert_that
 import numpy as np
@@ -46,11 +46,11 @@ def run_test(n_samples):
         writer = DatasetWriter(name, {
             'index': IntField(),
             'activations': JSONField()
-        }, num_workers=3)
+        }, num_workers=min(3, cpu_count()))
 
         writer.from_indexed_dataset(dataset)
 
-        loader = Loader(name, batch_size=3, num_workers=5,
+        loader = Loader(name, batch_size=3, num_workers=min(5, cpu_count()),
                         pipelines={
                             'activation': [BytesDecoder()],
                             'index': [IntDecoder()]

--- a/tests/test_loader_filter.py
+++ b/tests/test_loader_filter.py
@@ -12,6 +12,7 @@ from assertpy import assert_that
 from tempfile import NamedTemporaryFile
 from ffcv.pipeline.operation import Operation
 from ffcv.transforms.ops import ToTensor
+from multiprocessing import cpu_count
 
 from ffcv.writer import DatasetWriter
 from ffcv.reader import Reader
@@ -52,7 +53,7 @@ def test_basic_simple():
 
         Compiler.set_enabled(True)
 
-        loader = Loader(file_name, batch_size, num_workers=5, seed=17,
+        loader = Loader(file_name, batch_size, num_workers=min(5, cpu_count()), seed=17,
                         pipelines={
                             'value': [FloatDecoder(), Doubler(), ToTensor()],
                         })

--- a/tests/test_partial_batches.py
+++ b/tests/test_partial_batches.py
@@ -12,6 +12,7 @@ from assertpy import assert_that
 from tempfile import NamedTemporaryFile
 from ffcv.pipeline.operation import Operation
 from ffcv.transforms.ops import ToTensor
+from multiprocessing import cpu_count
 
 from ffcv.writer import DatasetWriter
 from ffcv.reader import Reader
@@ -52,7 +53,7 @@ def run_test(bs, exp_length, drop_last=True):
 
         Compiler.set_enabled(True)
 
-        loader = Loader(file_name, batch_size, num_workers=5, seed=17,
+        loader = Loader(file_name, batch_size, num_workers=min(5, cpu_count()), seed=17,
                 drop_last=drop_last,
                         pipelines={
                             'value': [FloatDecoder(), Doubler(), ToTensor()]
@@ -77,5 +78,3 @@ def test_not_partial_multiple():
 
 def test_partial_multiple():
     run_test(60, 10, True)
-
-        

--- a/tests/test_partial_pipeline.py
+++ b/tests/test_partial_pipeline.py
@@ -12,6 +12,7 @@ from assertpy import assert_that
 from tempfile import NamedTemporaryFile
 from ffcv.pipeline.operation import Operation
 from ffcv.transforms.ops import ToTensor
+from multiprocessing import cpu_count
 
 from ffcv.writer import DatasetWriter
 from ffcv.reader import Reader
@@ -52,7 +53,7 @@ def test_basic_simple():
 
         Compiler.set_enabled(True)
 
-        loader = Loader(file_name, batch_size, num_workers=5, seed=17,
+        loader = Loader(file_name, batch_size, num_workers=min(5, cpu_count()), seed=17,
                         pipelines={
                             'value': [FloatDecoder(), Doubler(), ToTensor()],
                             'index': None
@@ -65,4 +66,3 @@ def test_basic_simple():
         values = result[0]
         assert_that(np.allclose(2 * np.sin(np.arange(batch_size)),
                                 values.squeeze().numpy())).is_true()
-        

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -6,6 +6,7 @@ import logging
 import os
 from assertpy import assert_that
 from tempfile import NamedTemporaryFile
+from multiprocessing import cpu_count
 
 from ffcv.writer import DatasetWriter
 from ffcv.reader import Reader
@@ -91,7 +92,7 @@ def test_multiple_workers():
         writer = DatasetWriter(name, {
             'index': IntField(),
             'value': FloatField()
-        }, num_workers=30)
+        }, num_workers=min(30, cpu_count()))
 
         writer.from_indexed_dataset(dataset, chunksize=10000)
 
@@ -106,7 +107,7 @@ def test_super_long():
         writer = DatasetWriter(name, {
             'index': IntField(),
             'value': FloatField()
-        }, num_workers=30)
+        }, num_workers=min(30, cpu_count()))
 
         writer.from_indexed_dataset(dataset, chunksize=10000)
 
@@ -120,6 +121,6 @@ def test_small_chunks_multiple_workers():
         writer = DatasetWriter(name, {
             'index': IntField(),
             'value': BytesField()
-        }, num_workers=30)
+        }, num_workers=min(30, cpu_count()))
 
         writer.from_indexed_dataset(dataset, chunksize=1)


### PR DESCRIPTION
This PR modifies the FFCV tests to work on consumer hardware by adding `cpu_count` checks and lowering the batch and size in `test_cuda_nonblocking.py`.

The `test_cuda_nonblocking.py` changes could be moved to a pytest config file with a pytest extension like [pytest-testconfig](https://pypi.org/project/pytest-testconfig), assuming pytest doesn't this built in and I am missing it.

The dataset writer tests currently hang on my machine, I believe I fixed this issue by [merging in](https://github.com/warner-benjamin/ffcv/tree/ffcvx) the fix-198 and FFCV 1.0 branches.