### PR TITLE
Correct new TraversalOrder

### DIFF
--- a/ffcv/loader/loader.py
+++ b/ffcv/loader/loader.py
@@ -156,7 +156,7 @@ class Loader:
 
         if order in ORDER_MAP:
             self.traversal_order: TraversalOrder = ORDER_MAP[order](self)
-        elif isinstance(order, TraversalOrder):
+        elif issubclass(order, TraversalOrder):
             self.traversal_order: TraversalOrder = order(self)
         else:
             raise ValueError(f"Order {order} is not a supported order type or a subclass of TraversalOrder")

--- a/ffcv/loader/loader.py
+++ b/ffcv/loader/loader.py
@@ -40,7 +40,7 @@ ORDER_TYPE = Union[
 
 ]
 
-ORDER_MAP: Mapping[ORDER_TYPE, TraversalOrder] = {
+ORDER_MAP: Mapping[ORDER_TYPE, Type[TraversalOrder]] = {
     OrderOption.RANDOM: Random,
     OrderOption.SEQUENTIAL: Sequential,
     OrderOption.QUASI_RANDOM: QuasiRandom


### PR DESCRIPTION
The correct check for a custom TraversalOrder should be that `order` is not a subclass of TraversalOrder and not an instance of it.