### PR TITLE
Correct CIFAR10_MEAN and CIFAR10_STD in train_cifar.py

### DIFF
--- a/examples/cifar/train_cifar.py
+++ b/examples/cifar/train_cifar.py
@@ -74,8 +74,8 @@ def make_dataloaders(train_dataset=None, val_dataset=None, batch_size=None, num_
     }
 
     start_time = time.time()
-    CIFAR_MEAN = [125.307, 122.961, 113.8575]
-    CIFAR_STD = [51.5865, 50.847, 51.255]
+    CIFAR_MEAN = [125.307, 122.950, 113.865]
+    CIFAR_STD = [62.993, 62.089, 66.705]
     loaders = {}
 
     for name in ['train', 'test']:


### PR DESCRIPTION
For some reason, the CIFAR10_STD used in the example differed significantly from the actual standard deviation of the CIFAR10 train dataset. I corrected both the MEAN and STD with 3 decimal places accuracy. 

I calculated the values as seen here: https://gist.github.com/epistoteles/c35bd5154a036748651d8caca11a7efe