### PR TITLE
Fix loader arg saving

### DIFF
--- a/ffcv/loader/loader.py
+++ b/ffcv/loader/loader.py
@@ -9,6 +9,7 @@ from re import sub
 from typing import Any, Callable, Mapping, Sequence, Type, Union, Literal
 from collections import defaultdict
 from collections.abc import Collection
+from copy import deepcopy
 from enum import Enum, unique, auto
 
 from ffcv.fields.base import Field
@@ -121,8 +122,8 @@ class Loader:
             'order': order,
             'distributed': distributed,
             'seed': seed,
-            'indices': indices,
-            'pipelines': pipelines,
+            'indices': deepcopy(indices),
+            'pipelines': deepcopy(pipelines),
             'drop_last': drop_last,
             'batches_ahead': batches_ahead,
             'recompile': recompile

--- a/ffcv/transforms/__init__.py
+++ b/ffcv/transforms/__init__.py
@@ -1,5 +1,5 @@
 from .cutout import Cutout
-from .flip import RandomHorizontalFlip
+from .flip import RandomHorizontalFlip, RandomVerticalFlip
 from .ops import ToTensor, ToDevice, ToTorchImage, Convert, View
 from .common import Squeeze
 from .random_resized_crop import RandomResizedCrop
@@ -15,7 +15,7 @@ __all__ = ['ToTensor', 'ToDevice',
            'ToTorchImage', 'NormalizeImage',
            'Convert',  'Squeeze', 'View',
            'RandomResizedCrop', 'RandomHorizontalFlip', 'RandomTranslate',
-           'Cutout', 'ImageMixup', 'LabelMixup', 'MixupToOneHot',
-           'Poison', 'ReplaceLabel',
+           'RandomVerticalFlip', 'Cutout', 'ImageMixup', 'LabelMixup',
+           'MixupToOneHot', 'Poison', 'ReplaceLabel',
            'ModuleWrapper',
            'RandomBrightness', 'RandomContrast', 'RandomSaturation']

--- a/ffcv/transforms/flip.py
+++ b/ffcv/transforms/flip.py
@@ -44,3 +44,40 @@ class RandomHorizontalFlip(Operation):
     def declare_state_and_memory(self, previous_state: State) -> Tuple[State, Optional[AllocationQuery]]:
         return (replace(previous_state, jit_mode=True), 
                 AllocationQuery(previous_state.shape, previous_state.dtype))
+
+
+class RandomVerticalFlip(Operation):
+    """Flip the image vertically with probability flip_prob.
+    Operates on raw arrays (not tensors).
+
+    Parameters
+    ----------
+    flip_prob : float
+        The probability with which to flip each image in the batch
+        vertically.
+    """
+
+    def __init__(self, flip_prob: float = 0.5):
+        super().__init__()
+        self.flip_prob = flip_prob
+
+    def generate_code(self) -> Callable:
+        my_range = Compiler.get_iterator()
+        flip_prob = self.flip_prob
+
+        def flip(images, dst):
+            should_flip = rand(images.shape[0]) < flip_prob
+            for i in my_range(images.shape[0]):
+                if should_flip[i]:
+                    dst[i] = images[i, ::-1, ...]
+                else:
+                    dst[i] = images[i]
+
+            return dst
+
+        flip.is_parallel = True
+        return flip
+
+    def declare_state_and_memory(self, previous_state: State) -> Tuple[State, Optional[AllocationQuery]]:
+        return (replace(previous_state, jit_mode=True), 
+                AllocationQuery(previous_state.shape, previous_state.dtype))

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -81,14 +81,24 @@ def test_cutout():
         ], comp, 'cutout')
 
 
-def test_flip():
+def test_horizontal_flip():
     for comp in [True, False]:
         run_test(100, [
             SimpleRGBImageDecoder(),
             RandomHorizontalFlip(1.0),
             ToTensor(),
             ToTorchImage()
-        ], comp, 'flip')
+        ], comp, 'hflip')
+
+
+def test_vertical_flip():
+    for comp in [True, False]:
+        run_test(100, [
+            SimpleRGBImageDecoder(),
+            RandomVerticalFlip(1.0),
+            ToTensor(),
+            ToTorchImage()
+        ], comp, 'vflip')
 
 
 def test_module_wrapper():


### PR DESCRIPTION
Fixes #316

Now, when running the example code in the issue and printing args:

```
{'fname': '/home/ec2-user/ffcv/tmp.beton',
 'batch_size': 100,
 'num_workers': 1,
 'os_cache': 0,
 'order': <OrderOption.RANDOM: 2>,
 'distributed': False,
 'seed': 1500678110,
 'indices': None,
 'pipelines': {'value': [<ffcv.fields.rgb_image.RandomResizedCropRGBImageDecoder at 0x7fc3bc9523a0>,
   <ffcv.transforms.flip.RandomHorizontalFlip at 0x7fc3bc952550>,
   <ffcv.transforms.ops.ToTensor at 0x7fc3bc952940>,
   <ffcv.transforms.ops.ToDevice at 0x7fc3bc9527c0>,
   <ffcv.transforms.ops.ToTorchImage at 0x7fc3bc952b50>,
   <ffcv.transforms.normalize.NormalizeImage at 0x7fc3bc952220>],
  'index': [<ffcv.fields.basics.IntDecoder at 0x7fc3bc952190>,
   <ffcv.transforms.ops.ToTensor at 0x7fc3bc975550>,
   <ffcv.transforms.common.Squeeze at 0x7fc3bc951ca0>,
   <ffcv.transforms.ops.ToDevice at 0x7fc3bc951490>]},
 'drop_last': True,
 'batches_ahead': 3,
 'recompile': False}
```
 Sorry about my previous PR being in here, let me know if you want me to properly split them