### PR TITLE
Deepcopy mutable loader args

### DIFF
--- a/ffcv/loader/loader.py
+++ b/ffcv/loader/loader.py
@@ -9,6 +9,7 @@ from re import sub
 from typing import Any, Callable, Mapping, Sequence, Type, Union, Literal
 from collections import defaultdict
 from collections.abc import Collection
+from copy import deepcopy
 from enum import Enum, unique, auto
 
 from ffcv.fields.base import Field
@@ -121,8 +122,8 @@ class Loader:
             'order': order,
             'distributed': distributed,
             'seed': seed,
-            'indices': indices,
-            'pipelines': pipelines,
+            'indices': deepcopy(indices),
+            'pipelines': deepcopy(pipelines),
             'drop_last': drop_last,
             'batches_ahead': batches_ahead,
             'recompile': recompile


### PR DESCRIPTION
Fixes #316

Now, when running the example code in the issue and printing args:

```
{'fname': '/home/ec2-user/ffcv/tmp.beton',
 'batch_size': 100,
 'num_workers': 1,
 'os_cache': 0,
 'order': <OrderOption.RANDOM: 2>,
 'distributed': False,
 'seed': 1500678110,
 'indices': None,
 'pipelines': {'value': [<ffcv.fields.rgb_image.RandomResizedCropRGBImageDecoder at 0x7fc3bc9523a0>,
   <ffcv.transforms.flip.RandomHorizontalFlip at 0x7fc3bc952550>,
   <ffcv.transforms.ops.ToTensor at 0x7fc3bc952940>,
   <ffcv.transforms.ops.ToDevice at 0x7fc3bc9527c0>,
   <ffcv.transforms.ops.ToTorchImage at 0x7fc3bc952b50>,
   <ffcv.transforms.normalize.NormalizeImage at 0x7fc3bc952220>],
  'index': [<ffcv.fields.basics.IntDecoder at 0x7fc3bc952190>,
   <ffcv.transforms.ops.ToTensor at 0x7fc3bc975550>,
   <ffcv.transforms.common.Squeeze at 0x7fc3bc951ca0>,
   <ffcv.transforms.ops.ToDevice at 0x7fc3bc951490>]},
 'drop_last': True,
 'batches_ahead': 3,
 'recompile': False}
```

@andrewilyas 