### PR TITLE
Fix conda getting stuck at `solving environment`

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         git \
         ffmpeg
 
-RUN conda create -n ffcv python=3.9 \
+RUN conda update conda && \
+        conda create -n ffcv python=3.9 \
         cupy \
         pkg-config \
         compilers \


### PR DESCRIPTION
When building the docker image using the Dockerfile, the process always gets stuck at `solving environment`. This is fixed by updating conda.